### PR TITLE
Rename createStub() and makeStub()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ abstract class BasetestCase extends \PHPUnit\Framework\TestCase
 
 ### StubFactory
 
-Provides `createStub()` method to easily create objects while bypassing their constructor. 
+Provides `makeStub()` method to easily create objects while bypassing their constructor. 
 It creates instance of your object using reflection.
 
 Enable by `use StubFactory`.
@@ -79,10 +79,10 @@ class MyEntity
 ```
 
 When testing method `salute()`, you only need the tested class to have `property2` set, you don't want to worry about `property1`. 
-Therefore in your test you can initialize `MyEntity` using `createStub()` like this:
+Therefore in your test you can initialize `MyEntity` using `makeStub()` like this:
 
 ```php
-$myEntity = $this->createStub(MyEntity::class, ['property2' => 'world']);
+$myEntity = $this->makeStub(MyEntity::class, ['property2' => 'world']);
 
 self::assertSame('Hello world!', $myEntity->salute());
 ```
@@ -98,7 +98,7 @@ To enable support for [DynamicReturnTypePlugin](https://plugins.jetbrains.com/pl
     "methodCalls": [
         {
             "class": "\\Cdn77\\TestUtils\\Feature\\StubFactory",
-            "method": "createStub",
+            "method": "makeStub",
             "position": 0
         }
     ]

--- a/dynamicReturnTypeMeta.json
+++ b/dynamicReturnTypeMeta.json
@@ -2,7 +2,7 @@
     "methodCalls": [
         {
             "class": "\\Cdn77\\TestUtils\\Feature\\StubFactory",
-            "method": "createStub",
+            "method": "makeStub",
             "position": 0
         }
     ]

--- a/src/Feature/StubFactory.php
+++ b/src/Feature/StubFactory.php
@@ -28,7 +28,7 @@ trait StubFactory
     /**
      * @param mixed[] $properties
      */
-    protected function createStub(string $class, array $properties = []) : object
+    protected function makeStub(string $class, array $properties = []) : object
     {
         $reflection = new ReflectionClass($class);
 

--- a/tests/Feature/StubFactoryTest.php
+++ b/tests/Feature/StubFactoryTest.php
@@ -15,7 +15,7 @@ final class StubFactoryTest extends BaseTestCase
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('null returned');
 
-        $stub = $this->createStub(SimpleClass::class);
+        $stub = $this->makeStub(SimpleClass::class);
 
         $stub->getProperty1();
 
@@ -24,14 +24,14 @@ final class StubFactoryTest extends BaseTestCase
 
     public function testPropertyIsSetBypassingConstructor() : void
     {
-        $stub = $this->createStub(SimpleClass::class, ['property1' => 'value']);
+        $stub = $this->makeStub(SimpleClass::class, ['property1' => 'value']);
 
         self::assertSame('value', $stub->getProperty1());
     }
 
     public function testParentPropertyIsSetBypassingConstructor() : void
     {
-        $stub = $this->createStub(SimpleClass::class, ['parentProperty' => 'value']);
+        $stub = $this->makeStub(SimpleClass::class, ['parentProperty' => 'value']);
 
         self::assertSame('value', $stub->getParentProperty());
     }
@@ -41,6 +41,6 @@ final class StubFactoryTest extends BaseTestCase
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage('Property "nonexistentProperty" not found');
 
-        $this->createStub(SimpleClass::class, ['nonexistentProperty' => 'value']);
+        $this->makeStub(SimpleClass::class, ['nonexistentProperty' => 'value']);
     }
 }

--- a/tests/Utils/PHPStan/Extension/MakeStub.php
+++ b/tests/Utils/PHPStan/Extension/MakeStub.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Cdn77\TestUtils\Tests\Utils\PHPStan\Extension;
 
-use Cdn77\TestUtils\PHPStan\CreateStubExtension;
+use Cdn77\TestUtils\PHPStan\MakeStubExtension;
 use Cdn77\TestUtils\Tests\BaseTestCase;
 
-final class CreateStub extends CreateStubExtension
+final class MakeStub extends MakeStubExtension
 {
     public function getClass() : string
     {

--- a/tests/Utils/PHPStan/Extension/extension.neon
+++ b/tests/Utils/PHPStan/Extension/extension.neon
@@ -1,5 +1,5 @@
 services:
 	-
-		class: Cdn77\TestUtils\Tests\Utils\PHPStan\Extension\CreateStub
+		class: Cdn77\TestUtils\Tests\Utils\PHPStan\Extension\MakeStub
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/pull/3810 introduced `TestCase::createStub()` as alias to `TestCase::createMock()`

Even though I disagree with statement that stub is also a mock, we have to rename our method so signatures do not conflict.